### PR TITLE
pg v4.5.1

### DIFF
--- a/npm/pg.json
+++ b/npm/pg.json
@@ -1,5 +1,6 @@
 {
   "versions": {
+    "4.5.1": "github:goenning/typed-pg#7688e0ebd8363f136e79c70e2d20f060be235b4b",
     "4.4.4": "github:goenning/typed-pg#83236e7c54254e5e4135efc79280c91d3ba2d819"
   }
 }


### PR DESCRIPTION
Updating pg to 4.5.1

Typings URL: https://github.com/goenning/typed-pg
Source URL: https://github.com/brianc/node-postgres
